### PR TITLE
Implement InputPin for Debounce

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,3 +100,15 @@ impl<T: Wait + InputPin> Wait for Debouncer<T> {
     }
 
 }
+
+impl<T: Wait + InputPin> InputPin for Debouncer<T> {
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        self.input.is_high()
+    }
+
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        self.input.is_low()
+    }
+}


### PR DESCRIPTION
After building a Debouncer that is owning the input pin, it can still be handy to be able to call .is_high() and .is_low().