### PR TITLE
Refactor debounce logic to use with_timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["async", "no_std", "IO", "debounce"]
 [dependencies]
 embedded-hal = "1.0.0"
 embedded-hal-async = "1.0.0"
-embassy-time = "0.4"
+embassy-time = "0.5"


### PR DESCRIPTION
I like the general idea and want to use it for my project, however the original implementation doesn't reset the debounce timer when bouncing is detected. 
After detecting an edge, it would wait for a fixed duration and then check the final state. If bouncing occurred during this period, the timer wouldn't restart.

I replaced the fixed timers with timeout-based monitoring that restarts the debounce period whenever bouncing is detected.